### PR TITLE
[CHHYBRID-4320] Updated z-schema dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-json-validation",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "dist/index.js",
   "scripts": {
     "build": "rimraf dist && tsc",
@@ -13,7 +13,7 @@
   },
   "typings": "./dist/index.d.ts",
   "dependencies": {
-    "z-schema": "3.18.4"
+    "z-schema": "~3.21.0"
   },
   "devDependencies": {
     "typescript": "2.5.2",


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/CHHYBRID-4320

Updating [z-schema](https://github.com/zaggino/z-schema) version from v3.18.4 -> v~3.21.0 changes a transitive dependency on [validator](https://github.com/chriso/validator.js) (v8.0.0 -> v10.0.0) that [fixes a ReDoS vulnerability](https://github.com/chriso/validator.js/commit/19508354cde4e08c75b377321a3d5f910dddee4e#diff-2133470579720aaf8cdd154075553315R14).